### PR TITLE
Last changes to db-hookup

### DIFF
--- a/packages/app/config/environment.ts
+++ b/packages/app/config/environment.ts
@@ -61,7 +61,7 @@ const ENV: ConfigType = {
     process.env.NEXT_PUBLIC_UNISWAPV2ROUTER_ADDRESS,
     'NEXT_PUBLIC_UNISWAPV2ROUTER_ADDRESS',
   ) as Address,
-  databaseUrl: required(process.env.NEXT_PUBLIC_DATABASE_URL, 'NEXT_PUBLIC_DATABASE_URL'),
+  databaseUrl: required(process.env.DATABASE_URL, 'DATABASE_URL'),
 };
 
 function required(value: string | undefined, name: string): string {

--- a/packages/app/middleware.ts
+++ b/packages/app/middleware.ts
@@ -1,0 +1,15 @@
+import { NextResponse, NextRequest } from 'next/server';
+
+export function middleware(request: NextRequest) {
+  const pathname = request.nextUrl.pathname;
+  if (pathname.startsWith('api')) {
+    // TODO check authenticated session
+    // TODO protect api routes PUT/POST/DELETE to require global admin rights
+  }
+  return NextResponse.next();
+}
+
+export const config = {
+  // Do not run the middleware on the following paths
+  matcher: '/((?!_next/static|_next/image|manifest.json|assets|favicon*|images|logos).*)',
+};


### PR DESCRIPTION
This PR changes the ENV var DATABASE_URL to not have a NEXT_PUBLIC_... prefix as it's not needed on the client side. It also adds an empty middleware.ts for future use to protect the api/ routes.