### PR TITLE
Wagmi connector for Silk

### DIFF
--- a/packages/app/components/AxeSwap/Buy.tsx
+++ b/packages/app/components/AxeSwap/Buy.tsx
@@ -105,7 +105,7 @@ const Buy: React.FC<TradeFormProps> = ({ reserves, swapBalance, axeBalance, onUp
   }, [swapLoading, swapSuccess, swapError, onUpdate]);
 
   useEffect(() => {
-    if (allowance && allowance < amountIn) {
+    if (allowance !== undefined && allowance < amountIn) {
       setExceedsAllowance(true);
     } else setExceedsAllowance(false);
   }, [amountIn, allowance]);

--- a/packages/app/components/WalletContext.tsx
+++ b/packages/app/components/WalletContext.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { createContext, useContext } from 'react';
-import { WalletClient } from 'viem';
+import { Address, WalletClient } from 'viem';
 
 type WalletContextType = {
   connected: boolean | undefined;
@@ -12,7 +12,8 @@ type WalletContextType = {
   setUserAddress: React.Dispatch<React.SetStateAction<string>>;
   currentNetwork: string;
   setCurrentNetwork: React.Dispatch<React.SetStateAction<string>>;
-  initializeWalletClient: () => void;
+  initializeWalletClient: (account: Address) => void;
+  verifyConnection: () => Promise<void>;
 };
 
 const WalletContext = createContext<WalletContextType | undefined>(undefined);
@@ -20,7 +21,7 @@ const WalletContext = createContext<WalletContextType | undefined>(undefined);
 export const useWallet = () => {
   const context = useContext(WalletContext);
   if (context === undefined) {
-    throw new Error('useWallet must be used within a WagmiProvider');
+    throw new Error('useWallet must be used within a WalletContext.Provider');
   }
   return context;
 };

--- a/packages/app/config/wagmi.ts
+++ b/packages/app/config/wagmi.ts
@@ -1,9 +1,11 @@
-import { createConfig, http } from 'wagmi';
+import { Transport } from 'viem';
+import { Config, createConfig, http } from 'wagmi';
 import { Chain, gnosis, localhost, optimism, sepolia } from 'wagmi/chains';
+import { injected } from 'wagmi/connectors';
 
 import ENV from '@/config/environment';
 
-const configureChains = (): [Chain, ...Chain[]] => {
+export const configureChains = (): [Chain, ...Chain[]] => {
   let chains: [Chain, ...Chain[]] = [gnosis];
   const appEnv = process.env.NEXT_PUBLIC_APP_ENV?.toLowerCase();
   if (appEnv === 'local') chains = [localhost];
@@ -12,13 +14,55 @@ const configureChains = (): [Chain, ...Chain[]] => {
   return chains;
 };
 
-const wagmiConfig = createConfig({
+export const getTransport = (chain: Chain): Transport => {
+  switch (chain.id) {
+    case gnosis.id:
+      return http(ENV.gnosisProviderUrl);
+    case optimism.id:
+      return http(ENV.optimismProviderUrl);
+    case sepolia.id:
+      return http(ENV.sepoliaProviderUrl);
+    case localhost.id:
+      return http('http://127.0.0.1:8545');
+    default:
+      return http();
+  }
+};
+
+export const createSilkConfig = (): Config => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const isSilkAvailable = typeof window !== 'undefined' && typeof (window as any).silk !== 'undefined';
+  return createConfig({
+    chains: configureChains(),
+    connectors: isSilkAvailable
+      ? [
+          injected({
+            target() {
+              return {
+                id: 'silkProvider',
+                name: 'Silk Secure Provider',
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                provider: (window as any).silk,
+              };
+            },
+          }),
+        ]
+      : [],
+    transports: {
+      [optimism.id]: http(ENV.optimismProviderUrl),
+      [gnosis.id]: http(ENV.gnosisProviderUrl),
+      [sepolia.id]: http(ENV.sepoliaProviderUrl),
+      [localhost.id]: http('http://127.0.0.1:8545'),
+    },
+  });
+};
+
+/**
+ * Default wagmi configuration
+ */
+const wagmiConfig: Config = createConfig({
   chains: configureChains(),
-  connectors: [
-    // injected(),
-    // metaMask(metaMaskConfig),
-    // safe(),
-  ],
+  connectors: [],
   transports: {
     [optimism.id]: http(ENV.optimismProviderUrl),
     [gnosis.id]: http(ENV.gnosisProviderUrl),

--- a/packages/app/db/index.ts
+++ b/packages/app/db/index.ts
@@ -60,7 +60,7 @@ export async function fetchSessionData(walletAddress: string): Promise<UserSessi
   if (!walletAddress) return undefined;
   return await db.query.users.findFirst({
     where: (users, { eq }) => eq(users.walletAddress, walletAddress),
-    columns: { id: true, email: true, walletAddress: true, isGlobalAdmin: true },
+    columns: { id: true, walletAddress: true, isGlobalAdmin: true },
   });
 }
 

--- a/packages/app/hooks/useAuth.ts
+++ b/packages/app/hooks/useAuth.ts
@@ -4,7 +4,6 @@ import { useState } from 'react';
 import { SiweMessage } from 'siwe';
 import { Address, createWalletClient, custom } from 'viem';
 
-import { getNetwork } from '@/app/_providers/silk.provider';
 import { useWallet } from '@/components/WalletContext';
 import { PATHS } from '@/config/constants';
 import { useProfileActions } from '@/store/profile.store';
@@ -16,8 +15,8 @@ import { useProfileActions } from '@/store/profile.store';
 const useAuth = () => {
   const [loginError, setLoginError] = useState<string | null>(null);
   const [signInError, setSignInError] = useState<string | null>(null);
-  const [silkEmail, setSilkEmail] = useState<string | null>(null);
-  const { connected, setConnected, walletClient, setWalletClient, userAddress, setUserAddress, currentNetwork } =
+  // const [silkEmail, setSilkEmail] = useState<string | null>(null);
+  const { connected, setConnected, walletClient, setWalletClient, userAddress, setUserAddress, verifyConnection } =
     useWallet();
   const router = useRouter();
   const { initializeProfile, clearProfile } = useProfileActions();
@@ -72,16 +71,7 @@ const useAuth = () => {
       //   return;
       // }
       // setSilkEmail(email);
-
-      const newWalletClient = createWalletClient({
-        chain: getNetwork(currentNetwork),
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        transport: custom((window as any).silk as any),
-      });
-      setWalletClient(newWalletClient);
-      setConnected(true);
-      const [address] = await newWalletClient.requestAddresses();
-      setUserAddress(address);
+      return verifyConnection();
     } catch (error) {
       console.error(error);
       setLoginError('Error during login: ' + error);


### PR DESCRIPTION
Adding a small change to the silk.provider component to keep the wagmiConfig in state and inject window.silk wallet as a connector. This enables wagmi readContract hooks, however, writeContract has issues in silk-sdk flow.
This is an improvement, because it allows a large portion of the UI to be driven by wagmi hooks.