### PR TITLE
HotFix for eth_getLogs rate limits from RPC providers

### DIFF
--- a/apps/quilombo/app/(main)/dao/page.tsx
+++ b/apps/quilombo/app/(main)/dao/page.tsx
@@ -3,7 +3,7 @@
 import { Tab, Tabs } from '@nextui-org/tabs';
 import { useQueryState } from 'nuqs';
 
-import { CouncilPanel, DaoMembership, Proposals, Treasury, TreasuryShares } from '@/components/axe/dao';
+import { CouncilPanel, DaoMembership, Treasury, TreasuryShares } from '@/components/axe/dao';
 
 const DaoPage = () => {
   const [tab, setTab] = useQueryState('tab', {
@@ -39,7 +39,7 @@ const DaoPage = () => {
           <div className="flex w-full flex-col gap-2 sm:gap-4 items-center">
             <h2 className="text-3xl font-bold text-center mb-1">Proposals</h2>
             <p className="text-center">The following proposals are currently active.</p>
-            <Proposals />
+            {/* <Proposals /> commented out due to eth_getLogs rate limits */}
           </div>
         </Tab>
         <Tab key="assets" title="Assets" className="w-full">

--- a/apps/quilombo/components/axe/dao/Candidates.tsx
+++ b/apps/quilombo/components/axe/dao/Candidates.tsx
@@ -4,18 +4,22 @@ import { useEffect } from 'react';
 import { useAtomValue, useSetAtom } from 'jotai';
 
 import UserCard from '@/components/UserCard';
-import { candidatesSyncEnabledAtom, sortedCandidateUsersAtom } from '@/hooks/state/dao';
+import { sortedCandidateUsersAtom } from '@/hooks/state/dao';
+import { useCandidatesSync } from '@/hooks/state/dao';
+import { directCandidatesSyncEnabledAtom } from '@/hooks/state/dao';
 
 export default function Candidates() {
   const candidates = useAtomValue(sortedCandidateUsersAtom);
-  const setCandidatesSyncEnabled = useSetAtom(candidatesSyncEnabledAtom);
+  const setDirectSync = useSetAtom(directCandidatesSyncEnabledAtom);
+
+  useCandidatesSync();
 
   useEffect(() => {
-    setCandidatesSyncEnabled(true);
+    setDirectSync(true);
     return () => {
-      setCandidatesSyncEnabled(false);
+      setDirectSync(false);
     };
-  }, [setCandidatesSyncEnabled]);
+  }, [setDirectSync]);
 
   return (
     <div className="w-full flex flex-col gap-4">

--- a/apps/quilombo/components/axe/dao/RequestCouncilUpdateButton.tsx
+++ b/apps/quilombo/components/axe/dao/RequestCouncilUpdateButton.tsx
@@ -3,10 +3,13 @@
 import { Button } from '@nextui-org/button';
 import { useReadAxeMembershipCouncilCanRequestCouncilUpdate } from '@/generated';
 import { useCouncilUpdateRequest } from '@/hooks/state/dao';
+import ENV from '@/config/environment';
 
 export default function RequestCouncilUpdateButton() {
   const { requestUpdate, isPending: isUpdatePending } = useCouncilUpdateRequest();
-  const { data: canRequestUpdate } = useReadAxeMembershipCouncilCanRequestCouncilUpdate();
+  const { data: canRequestUpdate, isLoading } = useReadAxeMembershipCouncilCanRequestCouncilUpdate({
+    address: ENV.axeMembershipCouncilAddress,
+  });
 
   return (
     <div className="flex flex-col items-center gap-4">
@@ -18,7 +21,7 @@ export default function RequestCouncilUpdateButton() {
         color="primary"
         className="max-w-[300px] w-full opacity-100 transition-opacity"
         isDisabled={!canRequestUpdate}
-        isLoading={isUpdatePending}
+        isLoading={isUpdatePending || isLoading}
         onPress={() => requestUpdate()}
       >
         Request Council Update

--- a/apps/quilombo/query/dao.ts
+++ b/apps/quilombo/query/dao.ts
@@ -6,7 +6,7 @@ import type { Candidate } from '@/hooks/state/dao';
 import { type GetCandidatesParams, QUERY_KEYS } from '.';
 import { queryOptions, useQuery } from '@tanstack/react-query';
 
-type CandidateResult = {
+export type CandidateResult = {
   delegationCount: bigint;
   available: boolean;
   next: Address;
@@ -18,7 +18,7 @@ type GetCandidateChangesParams = {
   toBlock?: bigint;
 };
 
-type GetTopCandidatesParams = {
+export type GetTopCandidatesParams = {
   offset?: number;
   pageSize?: number;
   publicClient?: PublicClient;


### PR DESCRIPTION
This PR fixes the candidates retrieval to use `getTopCandidates` on the contract instead of querying event logs. The RPC providers have rate limits of only 500 blocks per call.
The same problem exists on the Proposals component and the component was temporarily removed (commented).
The PR also fixes a missing contract address to read canRequestCouncilUpdate.