### PR TITLE
fix: new env vars WALLET_ENV, CHAIN_ENV

### DIFF
--- a/apps/quilombo/config/environment.ts
+++ b/apps/quilombo/config/environment.ts
@@ -3,6 +3,8 @@ import type { EnvType } from '@/types';
 
 type ConfigType = {
   environment: EnvType;
+  walletEnvironment: EnvType;
+  chainEnvironment: EnvType;
   walletConnectProjectId: string;
   sepoliaProviderUrl: string;
   gnosisProviderUrl: string;
@@ -47,6 +49,8 @@ export const getBaseUrl = () => {
 
 const ENV: ConfigType = {
   environment: required(envMode, 'NEXT_PUBLIC_APP_ENV') as EnvType,
+  walletEnvironment: required(envMode, 'NEXT_PUBLIC_WALLET_ENV') as EnvType,
+  chainEnvironment: required(envMode, 'NEXT_PUBLIC_CHAIN_ENV') as EnvType,
   walletConnectProjectId: required(
     process.env.NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID,
     'NEXT_PUBLIC_WALLET_CONNECT_PROJECT_ID'

--- a/apps/quilombo/config/silk.ts
+++ b/apps/quilombo/config/silk.ts
@@ -1,9 +1,9 @@
 import type { InitSilkOptions } from '@silk-wallet/silk-wallet-sdk';
 
-import ENV from './environment';
+import ENV from '@/config/environment';
 
 export const silkInitOptions: InitSilkOptions = {
-  useStaging: ENV.environment !== 'production',
+  useStaging: ENV.walletEnvironment !== 'production',
   config: {
     authenticationMethods: ['email', 'social'], // Empty array will allow all auth methods
     allowedSocials: ['google', 'discord'], // Empty array will allow all social providers

--- a/apps/quilombo/config/wagmi.ts
+++ b/apps/quilombo/config/wagmi.ts
@@ -22,14 +22,14 @@ export const getOrigin = () => {
 
 export const configureChains = (): [Chain, ...Chain[]] => {
   let chains: [Chain, ...Chain[]] = [gnosis];
-  if (ENV.environment === 'local') chains = [localhost];
-  else if (ENV.environment === 'development') chains = [sepolia];
-  console.info(`Chains configured for '${ENV.environment}' mode.`);
+  if (ENV.chainEnvironment === 'local') chains = [localhost];
+  else if (ENV.chainEnvironment === 'development') chains = [sepolia];
+  console.info(`Chains configured for '${ENV.chainEnvironment}' mode.`);
   return chains;
 };
 
 export const getDefaultChain = (): Chain => {
-  switch (ENV.environment) {
+  switch (ENV.chainEnvironment) {
     case 'local':
       return localhost;
     case 'development':


### PR DESCRIPTION
This PR adds two new ENV VARS to be able to control the chain config and wallet provider environment separately from the main app's mode.