### PR TITLE
Fix/middleware matcher

### DIFF
--- a/apps/quilombo/middleware.ts
+++ b/apps/quilombo/middleware.ts
@@ -39,5 +39,7 @@ export default withAuth(
 
 export const config = {
   // Do not run the middleware on static assets and auth pages, but everything else
-  matcher: '/((?!_next/static|_next/image|manifest.json|assets|favicon*|images|logos|auth).+)',
+  // Excludes: Next.js internals, static files with extensions in root, specific directories, and auth pages
+  matcher:
+    '/((?!_next/static|_next/image|manifest.json|.*\\.(?:ico|png|jpg|jpeg|svg|webp|gif)|assets|favicon*|images|logos|auth).+)',
 };


### PR DESCRIPTION
Fixes the regex used for the middleware matcher to correctly allow public access to images located in the public/ folder.