### PR TITLE
Prod Fix: always run db-migrate in prod and remove deploy hook

### DIFF
--- a/.github/workflows/db-migrate-production.yml
+++ b/.github/workflows/db-migrate-production.yml
@@ -42,45 +42,7 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Check for schema changes
-        id: check_changes
-        run: |
-          echo "Checking for database schema changes..."
-
-          # Check if there are new migration files or schema changes
-          CHANGED_FILES=$(git diff --name-only HEAD~1 HEAD)
-          echo "Changed files:"
-          echo "$CHANGED_FILES"
-
-          if echo "$CHANGED_FILES" | grep -qE "apps/quilombo/db/(migrations|schema\.ts)"; then
-            echo "has_changes=true" >> $GITHUB_OUTPUT
-            echo "✓ Database changes detected"
-          else
-            echo "has_changes=false" >> $GITHUB_OUTPUT
-            echo "ℹ No database changes detected"
-          fi
-
-      - name: Verify migration files exist
-        if: steps.check_changes.outputs.has_changes == 'true'
-        working-directory: apps/quilombo
-        run: |
-          if [ ! -d "db/migrations" ]; then
-            echo "❌ Migration directory not found"
-            exit 1
-          fi
-
-          MIGRATION_COUNT=$(ls -1 db/migrations/*.sql 2>/dev/null | wc -l)
-          echo "Found $MIGRATION_COUNT migration file(s)"
-
-          if [ "$MIGRATION_COUNT" -eq 0 ]; then
-            echo "❌ No migration files found"
-            exit 1
-          fi
-
-          echo "✓ Migration files verified"
-
       - name: Run production migrations
-        if: steps.check_changes.outputs.has_changes == 'true'
         working-directory: apps/quilombo
         env:
           DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
@@ -108,7 +70,7 @@ jobs:
           echo "✅ Migration completed successfully"
 
       - name: Create migration report
-        if: always() && steps.check_changes.outputs.has_changes == 'true'
+        if: always()
         run: |
           echo "# Migration Report" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -138,38 +100,3 @@ jobs:
         run: |
           echo "::error::Production database migration failed. Vercel deployment should be blocked."
           echo "::error::Check the logs above for details and follow rollback procedures if necessary."
-
-  # This job depends on migrate and only runs if migration succeeds
-  trigger-vercel-deployment:
-    name: Trigger Vercel Deployment
-    runs-on: ubuntu-latest
-    needs: migrate
-    if: success() # Only run if migration succeeded
-
-    steps:
-      - name: Trigger Vercel Deploy Hook
-        run: |
-          echo "🚀 Triggering Vercel deployment..."
-
-          RESPONSE=$(curl -X POST "${{ secrets.VERCEL_DEPLOY_HOOK_URL }}" \
-            -w "\n%{http_code}" \
-            -s)
-
-          HTTP_CODE=$(echo "$RESPONSE" | tail -n1)
-
-          if [ "$HTTP_CODE" = "201" ] || [ "$HTTP_CODE" = "200" ]; then
-            echo "✅ Vercel deployment triggered successfully (HTTP $HTTP_CODE)"
-          else
-            echo "❌ Failed to trigger Vercel deployment (HTTP $HTTP_CODE)"
-            echo "Response: $(echo "$RESPONSE" | head -n-1)"
-            exit 1
-          fi
-
-      - name: Deployment notification
-        run: |
-          echo "# Deployment Triggered" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "✅ Database migrations completed successfully" >> $GITHUB_STEP_SUMMARY
-          echo "🚀 Vercel deployment has been triggered" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Monitor deployment at: https://vercel.com/j-h-scheufen/axedao" >> $GITHUB_STEP_SUMMARY

--- a/apps/quilombo/docs/DB_MIGRATIONS.md
+++ b/apps/quilombo/docs/DB_MIGRATIONS.md
@@ -14,10 +14,11 @@ Your project now has **two separate migration workflows**:
 
 2. **Production Workflow** (`.github/workflows/db-migrate-production.yml`)
    - Triggers on push to `main` branch
+   - **Always runs migrations** (drizzle-kit handles "already applied" gracefully)
    - Runs migrations on **production database**
    - Uses `PRODUCTION_DATABASE_URL` secret
    - Script: `pnpm migrate:production`
-   - Triggers Vercel deployment after success
+   - Vercel auto-deploys via Git integration after workflow succeeds
 
 ## Why Two Workflows?
 
@@ -118,7 +119,6 @@ Add these secrets:
 |------------|---------|-------|
 | `STAGING_DATABASE_URL` | Staging workflow | Supabase staging DB connection string |
 | `PRODUCTION_DATABASE_URL` | Production workflow | Supabase production DB connection string |
-| `VERCEL_DEPLOY_HOOK_URL` | Production workflow | Vercel deploy hook URL (optional) |
 
 ### Connection String Format
 


### PR DESCRIPTION
This PR makes changes to the automatic db-migration and deploy-hook setup for production deployments.
- db-migrate now always runs. If there are no new migrations, it will gracefully handle that
- the deploy-hook was removed from db-migrate. If there are any problems with db-migrate, the CI check will prevent the app from being deployed