### PR TITLE
refactor: use built-in isClearable for StringSelect component

### DIFF
--- a/apps/quilombo/components/forms/StringSelect.tsx
+++ b/apps/quilombo/components/forms/StringSelect.tsx
@@ -1,6 +1,5 @@
-import { Button, Link, Select, SelectItem } from '@heroui/react';
+import { Select, SelectItem } from '@heroui/react';
 import { type FieldProps, useField } from 'formik';
-import { XIcon } from 'lucide-react';
 import { useMemo } from 'react';
 
 // TODO Known problem with Select. This got fixed: https://github.com/nextui-org/nextui/pull/3698. But it's not tested in the app yet.
@@ -30,24 +29,22 @@ const StringSelect = ({ options = [], label, size, ...props }: Props) => {
   const placeholder = `Select ${field.name}`;
 
   return (
-    <div className="w-full flex items-center gap-1 sm:gap-2">
-      <Select
-        {...field}
-        size={size}
-        label={label}
-        placeholder={placeholder}
-        classNames={{ value: 'capitalize' }}
-        aria-label={placeholder}
-        selectedKeys={selectedKeys}
-      >
-        {selectItems}
-      </Select>
-      {field.value ? (
-        <Button as={Link} href="#" variant="light" onPress={() => form.setValue(null)} isIconOnly>
-          <XIcon className="h-6 w-6 sm:h-7 sm:w-7" strokeWidth={1} />
-        </Button>
-      ) : null}
-    </div>
+    <Select
+      {...field}
+      size={size}
+      label={label}
+      placeholder={placeholder}
+      classNames={{ value: 'capitalize' }}
+      aria-label={placeholder}
+      selectedKeys={selectedKeys}
+      isClearable
+      onSelectionChange={(keys) => {
+        const value = keys === 'all' ? '' : Array.from(keys)[0]?.toString() || '';
+        form.setValue(value);
+      }}
+    >
+      {selectItems}
+    </Select>
   );
 };
 


### PR DESCRIPTION
This PR contains changes to use the built-in isClearable prop in StringSelect for consistent UX