### PR TITLE
fix: use 'development' env for staging DB migrations and add type safety

### DIFF
--- a/apps/quilombo/scripts/db-migrate-production.ts
+++ b/apps/quilombo/scripts/db-migrate-production.ts
@@ -19,7 +19,11 @@
 import { execSync } from 'node:child_process';
 import { sql } from 'drizzle-orm';
 
+import type { EnvType } from '../types';
 import { createDatabaseConnection } from '../db/connection';
+
+// Type-safe environment constant for production
+const PRODUCTION_ENV: EnvType = 'production';
 
 // Initialize database connection (will be validated in main())
 const { db } = createDatabaseConnection(process.env.DATABASE_URL || '');
@@ -257,9 +261,10 @@ async function main(): Promise<void> {
   log.info('='.repeat(80));
 
   // Safety check: ensure we're in production mode
-  if (process.env.NEXT_PUBLIC_APP_ENV !== 'production') {
+  const currentEnv = process.env.NEXT_PUBLIC_APP_ENV;
+  if (currentEnv !== PRODUCTION_ENV) {
     log.error('This script should only run in production environment');
-    log.error(`Current NEXT_PUBLIC_APP_ENV: ${process.env.NEXT_PUBLIC_APP_ENV}`);
+    log.error(`Current NEXT_PUBLIC_APP_ENV: ${currentEnv} (expected: ${PRODUCTION_ENV})`);
     process.exit(1);
   }
 

--- a/apps/quilombo/scripts/db-migrate-staging.ts
+++ b/apps/quilombo/scripts/db-migrate-staging.ts
@@ -13,13 +13,17 @@
  *
  * Environment Variables Required:
  *   DATABASE_URL - PostgreSQL connection string (staging)
- *   NEXT_PUBLIC_APP_ENV - Must be 'staging'
+ *   NEXT_PUBLIC_APP_ENV - Must be 'development' (staging environment)
  */
 
 import { execSync } from 'node:child_process';
 import { sql } from 'drizzle-orm';
 
+import type { EnvType } from '../types';
 import { createDatabaseConnection } from '../db/connection';
+
+// Type-safe environment constant for staging
+const STAGING_ENV: EnvType = 'development';
 
 // Initialize database connection (will be validated in main())
 const { db } = createDatabaseConnection(process.env.DATABASE_URL || '');
@@ -256,10 +260,11 @@ async function main(): Promise<void> {
   log.info('Staging Database Migration Runner');
   log.info('='.repeat(80));
 
-  // Safety check: ensure we're in staging mode
-  if (process.env.NEXT_PUBLIC_APP_ENV !== 'staging') {
+  // Safety check: ensure we're in staging mode (development env signifies staging)
+  const currentEnv = process.env.NEXT_PUBLIC_APP_ENV;
+  if (currentEnv !== STAGING_ENV) {
     log.error('This script should only run in staging environment');
-    log.error(`Current NEXT_PUBLIC_APP_ENV: ${process.env.NEXT_PUBLIC_APP_ENV}`);
+    log.error(`Current NEXT_PUBLIC_APP_ENV: ${currentEnv} (expected: ${STAGING_ENV})`);
     process.exit(1);
   }
 


### PR DESCRIPTION
- Change db-migrate-staging.ts to check for 'development' instead of 'staging'
- Change db-migrate-production.ts to use type-safe EnvType constants
- Import EnvType from types/index.ts for compile-time safety
- Improve error messages to show expected vs actual env values