### PR TITLE
fix: simplify drizzle.config.ts to avoid unnecessary env validation

### DIFF
--- a/.github/workflows/db-migrate-production.yml
+++ b/.github/workflows/db-migrate-production.yml
@@ -47,8 +47,6 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.PRODUCTION_DATABASE_URL }}
           NEXT_PUBLIC_APP_ENV: production
-          NEXT_PUBLIC_WALLET_ENV: production
-          NEXT_PUBLIC_CHAIN_ENV: development
         run: |
           echo "🚀 Starting production database migration..."
           echo "Timestamp: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"

--- a/.github/workflows/db-migrate-staging.yml
+++ b/.github/workflows/db-migrate-staging.yml
@@ -41,8 +41,6 @@ jobs:
         env:
           DATABASE_URL: ${{ secrets.STAGING_DATABASE_URL }}
           NEXT_PUBLIC_APP_ENV: development
-          NEXT_PUBLIC_WALLET_ENV: production
-          NEXT_PUBLIC_CHAIN_ENV: development
         run: |
           echo "🚀 Starting staging database migration..."
           echo "Timestamp: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"

--- a/apps/quilombo/drizzle.config.ts
+++ b/apps/quilombo/drizzle.config.ts
@@ -1,13 +1,19 @@
 import type { Config } from 'drizzle-kit';
 
-import ENV from './config/environment';
+// Simple config for migrations - only needs DATABASE_URL
+// Avoids loading full environment config with all its validations
+const databaseUrl = process.env.DATABASE_URL;
+
+if (!databaseUrl) {
+  throw new Error('DATABASE_URL environment variable is required for drizzle-kit');
+}
 
 export default {
   schema: './db/schema.ts',
   out: './db/migrations',
   dialect: 'postgresql',
   dbCredentials: {
-    url: ENV.databaseUrl,
+    url: databaseUrl,
   },
   extensionsFilters: ['postgis'],
   verbose: true,


### PR DESCRIPTION
- Read DATABASE_URL directly instead of importing full ENV config
- Prevents migration failures due to unrelated missing env vars
- Remove WALLET_ENV and CHAIN_ENV from migration workflows (not needed)