### PR TITLE
fix: decouple db connection factory from ENV to fix staging migration

### DIFF
--- a/apps/quilombo/db/connection.ts
+++ b/apps/quilombo/db/connection.ts
@@ -7,12 +7,15 @@
  * - Database migration scripts
  * - Standalone CLI tools
  * - Any script that needs database access
+ *
+ * IMPORTANT: This module does NOT import @/config/environment at the top level
+ * to allow migration scripts to import createDatabaseConnection without
+ * triggering validation of all environment variables.
  */
 
 import { drizzle, type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import postgres from 'postgres';
 
-import ENV from '@/config/environment';
 import * as schema from './schema';
 
 /**
@@ -53,15 +56,3 @@ export function createDatabaseConnection(
 
   return { client, db };
 }
-
-// Create database connection using centralized factory
-const { client: postgresClient, db: drizzleClient } = createDatabaseConnection(ENV.databaseUrl);
-
-export const client = postgresClient;
-
-declare global {
-  var database: PostgresJsDatabase<typeof schema> | undefined;
-}
-
-export const db = global.database || drizzleClient;
-if (process.env.NODE_ENV !== 'production') global.database = db;

--- a/apps/quilombo/db/index.ts
+++ b/apps/quilombo/db/index.ts
@@ -16,8 +16,23 @@
  * - stats: Public statistics
  */
 
-// Database connection (used by API routes and query modules)
-export { db, client } from './connection';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+
+import ENV from '@/config/environment';
+import { createDatabaseConnection } from './connection';
+import type * as schema from './schema';
+
+// Create database connection using centralized factory
+const { client: postgresClient, db: drizzleClient } = createDatabaseConnection(ENV.databaseUrl);
+
+export const client = postgresClient;
+
+declare global {
+  var database: PostgresJsDatabase<typeof schema> | undefined;
+}
+
+export const db = global.database || drizzleClient;
+if (process.env.NODE_ENV !== 'production') global.database = db;
 
 // Domain modules
 export * from './queries/users';

--- a/apps/quilombo/db/queries/events.ts
+++ b/apps/quilombo/db/queries/events.ts
@@ -7,7 +7,7 @@ import { and, count, eq, gte, ilike, isNotNull, lt, lte, or, sql, type SQLWrappe
 
 import { QUERY_DEFAULT_PAGE_SIZE, type eventTypes } from '@/config/constants';
 import * as schema from '@/db/schema';
-import { db } from '@/db/connection';
+import { db } from '@/db';
 
 /**
  * Searches events with flexible filtering and pagination.

--- a/apps/quilombo/db/queries/groupClaims.ts
+++ b/apps/quilombo/db/queries/groupClaims.ts
@@ -6,7 +6,7 @@
 import { eq } from 'drizzle-orm';
 
 import * as schema from '@/db/schema';
-import { db } from '@/db/connection';
+import { db } from '@/db';
 import { NotFoundError } from '@/utils/errors';
 import { addGroupAdmin } from './groups';
 

--- a/apps/quilombo/db/queries/groupLocations.ts
+++ b/apps/quilombo/db/queries/groupLocations.ts
@@ -6,7 +6,7 @@
 import { and, count, eq } from 'drizzle-orm';
 
 import * as schema from '@/db/schema';
-import { db } from '@/db/connection';
+import { db } from '@/db';
 
 /**
  * Fetches all locations for a specific group.

--- a/apps/quilombo/db/queries/groupVerifications.ts
+++ b/apps/quilombo/db/queries/groupVerifications.ts
@@ -7,7 +7,7 @@ import { and, count, eq, gte } from 'drizzle-orm';
 
 import { GROUP_VERIFICATION_COOLDOWN_MS } from '@/config/constants';
 import * as schema from '@/db/schema';
-import { db } from '@/db/connection';
+import { db } from '@/db';
 
 /**
  * Checks if a group can be verified (hasn't been verified by ANY user in the cooldown period).

--- a/apps/quilombo/db/queries/groups.ts
+++ b/apps/quilombo/db/queries/groups.ts
@@ -8,7 +8,7 @@ import { and, count, eq, ilike, ne, notExists, sql, type SQLWrapper } from 'driz
 import type { GroupSearchParams } from '@/config/validation-schema';
 import { QUERY_DEFAULT_PAGE_SIZE } from '@/config/constants';
 import * as schema from '@/db/schema';
-import { db } from '@/db/connection';
+import { db } from '@/db';
 import type { Group } from '@/types/model';
 
 /**

--- a/apps/quilombo/db/queries/invitations.ts
+++ b/apps/quilombo/db/queries/invitations.ts
@@ -6,7 +6,7 @@
 import { and, eq, gte, lt } from 'drizzle-orm';
 
 import * as schema from '@/db/schema';
-import { db } from '@/db/connection';
+import { db } from '@/db';
 import type { InvitationType } from '@/types/model';
 
 /**

--- a/apps/quilombo/db/queries/stats.ts
+++ b/apps/quilombo/db/queries/stats.ts
@@ -6,7 +6,7 @@
 import { count, countDistinct, eq, gte } from 'drizzle-orm';
 
 import * as schema from '@/db/schema';
-import { db } from '@/db/connection';
+import { db } from '@/db';
 
 export interface PublicStats {
   activeUsers: number;

--- a/apps/quilombo/db/queries/users.ts
+++ b/apps/quilombo/db/queries/users.ts
@@ -8,7 +8,7 @@ import { and, eq, ilike, inArray, isNotNull, or, sql, type SQLWrapper } from 'dr
 import type { UserSearchParams } from '@/config/validation-schema';
 import { QUERY_DEFAULT_PAGE_SIZE } from '@/config/constants';
 import * as schema from '@/db/schema';
-import { db } from '@/db/connection';
+import { db } from '@/db';
 import type { UserSession } from '@/types/model';
 
 /**


### PR DESCRIPTION
Moved db instance creation from connection.ts to db/index.ts to prevent migration scripts from loading full environment config. The connection.ts now exports only the createDatabaseConnection factory function, allowing migration scripts to pass DATABASE_URL directly without triggering ENV validation. Query modules updated to import from @/db instead of @/db/connection.