### PR TITLE
Fix duplicate country flags in group cards

### DIFF
--- a/apps/quilombo/db/queries/groups.ts
+++ b/apps/quilombo/db/queries/groups.ts
@@ -101,11 +101,13 @@ export async function searchGroups(
     .limit(pageSize)
     .offset(offset);
 
-  // Convert lastVerifiedAt strings to Date objects and ensure adminCount is a number
+  // Convert lastVerifiedAt strings to Date objects, ensure adminCount is a number,
+  // and deduplicate country codes (defensive programming)
   const rows = results.map((row) => ({
     ...row,
     lastVerifiedAt: row.lastVerifiedAt ? new Date(row.lastVerifiedAt) : null,
     adminCount: Number(row.adminCount),
+    countryCodes: [...new Set(row.countryCodes)], // Ensure unique country codes
   })) as Group[];
 
   return {
@@ -168,12 +170,14 @@ export async function fetchGroup(groupId: string): Promise<Group | undefined> {
 
   if (!result[0]) return undefined;
 
-  // Convert lastVerifiedAt string to Date object and ensure adminCount is a number
+  // Convert lastVerifiedAt string to Date object, ensure adminCount is a number,
+  // and deduplicate country codes (defensive programming)
   const group = result[0];
   return {
     ...group,
     lastVerifiedAt: group.lastVerifiedAt ? new Date(group.lastVerifiedAt) : null,
     adminCount: Number(group.adminCount),
+    countryCodes: [...new Set(group.countryCodes)], // Ensure unique country codes
   } as Group;
 }
 


### PR DESCRIPTION
## Summary

Fixes duplicate country flags appearing in group cards when a group has multiple locations in the same country.

- Added Set-based deduplication in `searchGroups()` and `fetchGroup()` database queries
- Ensures country codes are always unique at the API level

## Test plan

- Verify groups with multiple locations in the same country now show only one flag per country
- Confirm existing functionality for groups with locations in different countries remains unchanged