### PR TITLE
Add Turborepo for build caching and orchestration

### DIFF
--- a/.github/workflows/test-contracts.yml
+++ b/.github/workflows/test-contracts.yml
@@ -27,6 +27,14 @@ jobs:
           registry-url: https://registry.npmjs.org
           cache: "pnpm"
 
+      - name: Cache Turborepo
+        uses: actions/cache@v4
+        with:
+          path: .turbo
+          key: ${{ runner.os }}-turbo-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-turbo-
+
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@ node_modules
 # TypeScript build cache
 *.tsbuildinfo
 
+# Turborepo cache
+.turbo
+
 # backup files (NEVER commit these - may contain secrets)
 *.backup
 *.bak

--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
   "scripts": {
     "dev:app": "pnpm --filter quilombo dev -p 8080",
     "dev:www": "pnpm --filter www dev",
-    "lint": "pnpm -r lint",
-    "format": "pnpm -r format",
-    "build": "pnpm -r build",
-    "test": "pnpm -r test",
+    "lint": "turbo lint",
+    "format": "turbo format",
+    "build": "turbo build",
+    "test": "turbo test",
     "prepare": "husky"
   },
   "engines": {
@@ -32,6 +32,7 @@
     "@commitlint/config-conventional": "19.8.1",
     "husky": "9.1.7",
     "lint-staged": "16.1.2",
+    "turbo": "^2.6.1",
     "typescript": "5.8.3"
   },
   "lint-staged": {

--- a/packages/subgraph-moloch-v3/package.json
+++ b/packages/subgraph-moloch-v3/package.json
@@ -6,16 +6,18 @@
   },
   "scripts": {
     "codegen": "graph codegen",
-    "build": "graph build",
+    "build:subgraph": "graph build",
     "deploy": "graph deploy --node https://api.studio.thegraph.com/deploy/ axe-dao-moloch-v3",
     "create-local": "graph create --node http://localhost:8020/ axe-dao-moloch-v3",
     "remove-local": "graph remove --node http://localhost:8020/ axe-dao-moloch-v3",
     "deploy-local": "graph deploy --node http://localhost:8020/ --ipfs http://localhost:5001 axe-dao-moloch-v3",
-    "graph-test": "graph test"
+    "test:subgraph": "graph test"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.97.1",
     "@graphprotocol/graph-ts": "0.37.0"
   },
-  "devDependencies": { "matchstick-as": "0.6.0" }
+  "devDependencies": {
+    "matchstick-as": "0.6.0"
+  }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,9 @@ importers:
       lint-staged:
         specifier: 16.1.2
         version: 16.1.2
+      turbo:
+        specifier: ^2.6.1
+        version: 2.6.1
       typescript:
         specifier: 5.8.3
         version: 5.8.3
@@ -10170,6 +10173,40 @@ packages:
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  turbo-darwin-64@2.6.1:
+    resolution: {integrity: sha512-Dm0HwhyZF4J0uLqkhUyCVJvKM9Rw7M03v3J9A7drHDQW0qAbIGBrUijQ8g4Q9Cciw/BXRRd8Uzkc3oue+qn+ZQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  turbo-darwin-arm64@2.6.1:
+    resolution: {integrity: sha512-U0PIPTPyxdLsrC3jN7jaJUwgzX5sVUBsKLO7+6AL+OASaa1NbT1pPdiZoTkblBAALLP76FM0LlnsVQOnmjYhyw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  turbo-linux-64@2.6.1:
+    resolution: {integrity: sha512-eM1uLWgzv89bxlK29qwQEr9xYWBhmO/EGiH22UGfq+uXr+QW1OvNKKMogSN65Ry8lElMH4LZh0aX2DEc7eC0Mw==}
+    cpu: [x64]
+    os: [linux]
+
+  turbo-linux-arm64@2.6.1:
+    resolution: {integrity: sha512-MFFh7AxAQAycXKuZDrbeutfWM5Ep0CEZ9u7zs4Hn2FvOViTCzIfEhmuJou3/a5+q5VX1zTxQrKGy+4Lf5cdpsA==}
+    cpu: [arm64]
+    os: [linux]
+
+  turbo-windows-64@2.6.1:
+    resolution: {integrity: sha512-buq7/VAN7KOjMYi4tSZT5m+jpqyhbRU2EUTTvp6V0Ii8dAkY2tAAjQN1q5q2ByflYWKecbQNTqxmVploE0LVwQ==}
+    cpu: [x64]
+    os: [win32]
+
+  turbo-windows-arm64@2.6.1:
+    resolution: {integrity: sha512-7w+AD5vJp3R+FB0YOj1YJcNcOOvBior7bcHTodqp90S3x3bLgpr7tE6xOea1e8JkP7GK6ciKVUpQvV7psiwU5Q==}
+    cpu: [arm64]
+    os: [win32]
+
+  turbo@2.6.1:
+    resolution: {integrity: sha512-qBwXXuDT3rA53kbNafGbT5r++BrhRgx3sAo0cHoDAeG9g1ItTmUMgltz3Hy7Hazy1ODqNpR+C7QwqL6DYB52yA==}
+    hasBin: true
 
   type-check@0.3.2:
     resolution: {integrity: sha512-ZCmOJdvOWDBYJlzAoFkC+Q0+bUyEOS1ltgp1MGU03fqHG+dbi9tBFU2Rd9QKiDZFAYrhPh2JUf7rZRIuHRKtOg==}
@@ -24146,6 +24183,33 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  turbo-darwin-64@2.6.1:
+    optional: true
+
+  turbo-darwin-arm64@2.6.1:
+    optional: true
+
+  turbo-linux-64@2.6.1:
+    optional: true
+
+  turbo-linux-arm64@2.6.1:
+    optional: true
+
+  turbo-windows-64@2.6.1:
+    optional: true
+
+  turbo-windows-arm64@2.6.1:
+    optional: true
+
+  turbo@2.6.1:
+    optionalDependencies:
+      turbo-darwin-64: 2.6.1
+      turbo-darwin-arm64: 2.6.1
+      turbo-linux-64: 2.6.1
+      turbo-linux-arm64: 2.6.1
+      turbo-windows-64: 2.6.1
+      turbo-windows-arm64: 2.6.1
 
   type-check@0.3.2:
     dependencies:

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,41 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "globalDependencies": ["**/.env.*local"],
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": [".next/**", "!.next/cache/**", "dist/**", "out/**", "build/**", ".vercel/**"],
+      "env": [
+        "NEXT_PUBLIC_*",
+        "DATABASE_URL",
+        "NEXTAUTH_*",
+        "GOOGLE_*",
+        "MAILJET_*",
+        "PINATA_JWT",
+        "ETHERSCAN_API_KEY",
+        "GRAPH_API_KEY",
+        "NODE_ENV"
+      ]
+    },
+    "lint": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    },
+    "format": {
+      "outputs": [],
+      "cache": false
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "outputs": ["coverage/**"],
+      "env": ["TEST_*", "DATABASE_URL"]
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "db:*": {
+      "cache": false
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Integrates Turborepo to improve build performance in CI/CD and on Vercel through intelligent caching and task orchestration.

- Installed Turborepo and configured `turbo.json` with caching for build, lint, test tasks
- Updated root package.json scripts to use turbo commands
- Added Turborepo cache to GitHub Actions workflow for faster CI builds
- Fixed subgraph package.json to exclude it from default builds (renamed `build` to `build:subgraph`)
- Added `.turbo` to .gitignore

## Benefits

- Vercel deployments will skip unchanged builds using remote cache
- CI builds benefit from GitHub Actions cache
- Better task orchestration across monorepo packages
- Future-ready for shared package extraction

## Notes

- Subgraph excluded from default builds as intended