### PR TITLE
fix: add missing FilterChip for Show Past Events filter

### DIFF
--- a/apps/quilombo/components/events/Events.tsx
+++ b/apps/quilombo/components/events/Events.tsx
@@ -17,6 +17,7 @@ import { CountryFilter, FilterChipsContainer } from '@/components/filters';
 import SearchBar from '@/components/SearchBar';
 import CountryFilterChip from '@/components/groups/CountryFilterChip';
 import EventTypesFilterChip from './EventTypesFilterChip';
+import PastEventsFilterChip from './PastEventsFilterChip';
 import EventFilters, { type EventFilterValues } from './EventFilters';
 import CreateEventModal from './CreateEventModal';
 import EventsGrid from './EventsGrid';
@@ -111,6 +112,11 @@ const Events = () => {
     handleFiltersChange(newFilters);
   };
 
+  const handleClearPastEvents = () => {
+    const newFilters = { ...eventFilters, pastEvents: false };
+    handleFiltersChange(newFilters);
+  };
+
   const handleNewEventClick = () => {
     setIsEventModalOpen(true);
   };
@@ -186,6 +192,9 @@ const Events = () => {
             selectedEventTypes={eventFilters.eventTypes.filter((t): t is NonNullable<typeof t> => t !== undefined)}
             onClear={handleClearEventTypes}
           />
+        )}
+        {eventFilters.pastEvents && (
+          <PastEventsFilterChip pastEvents={eventFilters.pastEvents} onClear={handleClearPastEvents} />
         )}
       </FilterChipsContainer>
 

--- a/apps/quilombo/components/events/PastEventsFilterChip.tsx
+++ b/apps/quilombo/components/events/PastEventsFilterChip.tsx
@@ -1,0 +1,26 @@
+'use client';
+
+import { FilterChip } from '@/components/filters';
+
+type PastEventsFilterChipProps = {
+  pastEvents: boolean;
+  onClear: () => void;
+  onChipClick?: () => void;
+};
+
+/**
+ * Filter chip for past events status.
+ */
+const PastEventsFilterChip = ({ pastEvents, onClear, onChipClick }: PastEventsFilterChipProps) => {
+  return (
+    <FilterChip
+      label="Show Past Events"
+      items={[pastEvents ? 'Yes' : 'No']}
+      onClear={onClear}
+      onChipClick={onChipClick}
+      maxVisible={1}
+    />
+  );
+};
+
+export default PastEventsFilterChip;


### PR DESCRIPTION
## Changes

- **New component**: `PastEventsFilterChip.tsx` - displays the past events filter status
- **Updated**: `Events.tsx` to:
  - Import the new PastEventsFilterChip component
  - Add `handleClearPastEvents` handler for clearing the filter
  - Render the chip in FilterChipsContainer when pastEvents filter is active