### PR TITLE
fix: use getBaseUrl() for invitation email links to prevent undefined URLs

### DIFF
--- a/apps/quilombo/utils/email/email-config.ts
+++ b/apps/quilombo/utils/email/email-config.ts
@@ -73,7 +73,8 @@ export const emailTemplates = {
       from: EMAIL_SENDERS.community,
     },
     getTemplate: (invitationCode: string, inviterName: string, invitedEmail: string): ReactElement => {
-      const inviteUrl = `${process.env.NEXT_PUBLIC_APP_URL}/auth/signup?code=${invitationCode}&email=${encodeURIComponent(invitedEmail)}`;
+      const baseUrl = getBaseUrl();
+      const inviteUrl = `${baseUrl}/auth/signup?code=${invitationCode}&email=${encodeURIComponent(invitedEmail)}`;
       return InvitationEmail({ inviteUrl, inviterName, invitedEmail });
     },
   },


### PR DESCRIPTION
## Summary

Fixes broken invitation email links in production where the Accept Invitation button and copy/paste link showed `undefined/auth/signup?code=...` instead of the proper URL.

## Problem

The invitation email template in `apps/quilombo/utils/email/email-config.ts` was directly using `process.env.NEXT_PUBLIC_APP_URL` to construct the invite URL. When this environment variable is not set (e.g., in Vercel production where only `NEXT_PUBLIC_VERCEL_URL` is available), it resulted in `undefined` being used as the base URL.

## Solution

Changed the invitation template to use the `getBaseUrl()` helper function, which properly handles both:
- `NEXT_PUBLIC_VERCEL_URL` (automatically set by Vercel)
- `NEXT_PUBLIC_APP_URL` (manually configured)

This makes the invitation template consistent with all other email templates (verification, password reset, welcome, claim approved, group registered) which already use `getBaseUrl()`.

## Priority

🔴 **High** - This blocks user invitations in production