### PR TITLE
Fix: use getBaseUrl() for invite emails to prevent undefined in URL of action button

### DIFF
--- a/apps/quilombo/utils/email/email-config.ts
+++ b/apps/quilombo/utils/email/email-config.ts
@@ -73,7 +73,8 @@ export const emailTemplates = {
       from: EMAIL_SENDERS.community,
     },
     getTemplate: (invitationCode: string, inviterName: string, invitedEmail: string): ReactElement => {
-      const inviteUrl = `${process.env.NEXT_PUBLIC_APP_URL}/auth/signup?code=${invitationCode}&email=${encodeURIComponent(invitedEmail)}`;
+      const baseUrl = getBaseUrl();
+      const inviteUrl = `${baseUrl}/auth/signup?code=${invitationCode}&email=${encodeURIComponent(invitedEmail)}`;
       return InvitationEmail({ inviteUrl, inviterName, invitedEmail });
     },
   },


### PR DESCRIPTION
This PR deploys a critical fix to production that fixes the "Accept Invitation" URLs for email invites.