### PR TITLE
Fix: groups search totalCount problems

### DIFF
--- a/apps/quilombo/hooks/useGroupSearch.tsx
+++ b/apps/quilombo/hooks/useGroupSearch.tsx
@@ -100,7 +100,7 @@ const useGroupSearch = (params?: UseGroupSearchParams): UseGroupSearchResult => 
     searchTerm,
     setSearchTerm: debouncedSetSearchTerm,
     groups: groupResults,
-    totalCount: groupResults.length,
+    totalCount: data?.pages[0]?.totalCount ?? 0,
     isLoading: isFetching || isFetchingNextPage,
     hasNextPage,
     fetchNextPage,


### PR DESCRIPTION
The useGroupSearch hook was setting the totalCount no using the explicit value returned from the server.