### PR TITLE
fix: missing api/stats in middleware exclusion pattern

### DIFF
--- a/apps/quilombo/middleware.ts
+++ b/apps/quilombo/middleware.ts
@@ -38,8 +38,8 @@ export default withAuth(
 );
 
 export const config = {
-  // Do not run the middleware on static assets and auth pages, but everything else
-  // Excludes: Next.js internals, static files with extensions in root, specific directories, and auth pages
+  // Do not run the middleware on static assets, auth pages, and public API routes
+  // Excludes: Next.js internals, static files with extensions in root, specific directories, auth pages, and public APIs
   matcher:
-    '/((?!_next/static|_next/image|manifest.json|.*\\.(?:ico|png|jpg|jpeg|svg|webp|gif)|assets|favicon*|images|logos|auth).+)',
+    '/((?!_next/static|_next/image|manifest.json|.*\\.(?:ico|png|jpg|jpeg|svg|webp|gif)|assets|favicon*|images|logos|auth|api/stats).+)',
 };


### PR DESCRIPTION
Fixes a bug that api/stats was not publicly reachable and the stats were all zero on the home page for visitors.