### PR TITLE
fix(genealogy): missing truncate statements in pending-migration.sql

### DIFF
--- a/docs/genealogy/sql-imports/build/pending-migration.sql
+++ b/docs/genealogy/sql-imports/build/pending-migration.sql
@@ -14,6 +14,15 @@
 BEGIN;
 
 -- ============================================================
+-- PHASE 0: TRUNCATE ALL GENEALOGY TABLES
+-- ============================================================
+-- Order matters: statements has FKs to person_profiles and group_profiles
+
+TRUNCATE TABLE genealogy.statements CASCADE;
+TRUNCATE TABLE genealogy.person_profiles CASCADE;
+TRUNCATE TABLE genealogy.group_profiles CASCADE;
+
+-- ============================================================
 -- PHASE 1: UPSERT ENTITIES
 -- ============================================================
 


### PR DESCRIPTION
remove duplicates by truncating and perform new baseline import for genealogy