### PR TITLE
fix: qr code invite validation and Mailjet on staging

### DIFF
--- a/apps/quilombo/__tests__/app/api/invitations/validate.test.ts
+++ b/apps/quilombo/__tests__/app/api/invitations/validate.test.ts
@@ -222,6 +222,22 @@ describe('POST /api/invitations/validate', () => {
       expect(body.invitedEmail).toBeUndefined();
     });
 
+    it('should validate open invitation with null email (from QR code URL params)', async () => {
+      // When searchParams.get('email') returns null for QR codes, JSON.stringify includes it as null
+      // The route converts null to undefined before calling findValidInvitation
+      const request = new Request('http://localhost/api/invitations/validate', {
+        method: 'POST',
+        body: JSON.stringify({ code: invitationCode, email: null }),
+      });
+
+      const response = await POST(request);
+      const body = await getResponseJson(response);
+
+      expect(response.status).toBe(200);
+      expect(mockDb.findValidInvitation).toHaveBeenCalledWith(invitationCode, undefined);
+      expect(body.type).toBe('open');
+    });
+
     it('should validate open invitation with email parameter (ignored)', async () => {
       const request = new Request('http://localhost/api/invitations/validate', {
         method: 'POST',

--- a/apps/quilombo/app/api/public/invitations/validate/route.ts
+++ b/apps/quilombo/app/api/public/invitations/validate/route.ts
@@ -86,8 +86,8 @@ export async function POST(request: Request) {
     // Validate request body
     const validatedData = await validateInvitationSchema.validate(body, { abortEarly: true });
 
-    // Find valid invitation
-    const invitation = await findValidInvitation(validatedData.code, validatedData.email);
+    // Find valid invitation (convert null to undefined for function signature)
+    const invitation = await findValidInvitation(validatedData.code, validatedData.email ?? undefined);
 
     if (!invitation) {
       // Generic error to prevent user enumeration

--- a/apps/quilombo/config/environment.ts
+++ b/apps/quilombo/config/environment.ts
@@ -128,12 +128,16 @@ const ENV: ConfigType = {
   axeDaoEmail: required(process.env.NEXT_PUBLIC_DAO_EMAIL, 'NEXT_PUBLIC_DAO_EMAIL'),
   quilomboSignalGroup: required(process.env.NEXT_PUBLIC_SIGNAL_GROUP, 'NEXT_PUBLIC_SIGNAL_GROUP'),
   mailjetApiKey:
-    isServer && envMode !== 'local' && envMode !== 'development'
-      ? required(process.env.MAILJET_API_KEY, 'MAILJET_API_KEY')
+    isServer && envMode !== 'local'
+      ? envMode === 'production'
+        ? required(process.env.MAILJET_API_KEY, 'MAILJET_API_KEY')
+        : process.env.MAILJET_API_KEY || ''
       : '',
   mailjetApiSecret:
-    isServer && envMode !== 'local' && envMode !== 'development'
-      ? required(process.env.MAILJET_API_SECRET, 'MAILJET_API_SECRET')
+    isServer && envMode !== 'local'
+      ? envMode === 'production'
+        ? required(process.env.MAILJET_API_SECRET, 'MAILJET_API_SECRET')
+        : process.env.MAILJET_API_SECRET || ''
       : '',
   smtpHost: isServer && envMode === 'local' ? required(process.env.SMTP_HOST, 'SMTP_HOST') : 'localhost',
   smtpPort: isServer && envMode === 'local' ? Number(required(process.env.SMTP_PORT, 'SMTP_PORT')) : 2500,

--- a/apps/quilombo/config/validation-schema.ts
+++ b/apps/quilombo/config/validation-schema.ts
@@ -456,7 +456,7 @@ export const invitationSchema = object({
 
 export const validateInvitationSchema = object({
   code: string().uuid('Invalid invitation code').required('Invitation code is required'),
-  email: string().email('Invalid email address').lowercase().trim().optional(), // Optional - only validated for email_bound
+  email: string().email('Invalid email address').lowercase().trim().nullable().optional(), // Optional - for open invites; nullable for JSON null from searchParams
 });
 
 export type InvitationForm = InferType<typeof invitationSchema>;


### PR DESCRIPTION
  - Allow null email in invitation validation for open invites
  - Enable Mailjet env vars on development/staging (optional, required only in production)